### PR TITLE
Patch block break data loss issue (#793)

### DIFF
--- a/main/src/main/java/me/blackvein/quests/Quester.java
+++ b/main/src/main/java/me/blackvein/quests/Quester.java
@@ -2590,7 +2590,7 @@ public class Quester {
 					plugin.getLogger().severe("[Quests] Invalid stage number for player: \"" + id + "\" on Quest \"" + quest.getName() + "\". Quest ended.");
 					continue;
 				}
-				addEmptiesFor(quest, 0);
+				addEmptiesFor(quest, currentQuests.get(quest));
 				if (questSec == null)
 					continue;
 				if (questSec.contains("blocks-broken-names")) {


### PR DESCRIPTION
This fixes the issue where progress from block break quests resets on relog or reboot (#793 #772).

When loading the data, it's attempting to set the blocks broken into a list at certain indices instead of appending them, requiring a pre-allocated list made by addEmptiesFor. The stage number for this was hardcoded to be the first stage only, so any stages past that will lose their data.

I would recommend changing the way this data is being added to the list or add more checks, as the way it's done is pretty unsafe (lines 2610, 2629, 2647, etc.), but this fix should work fine regardless.

https://github.com/PikaMug/Quests/blob/0dfe461b715066d7b12256a725dcebbe8afb8cc8/main/src/main/java/me/blackvein/quests/Quester.java#L2609-L2611