### PR TITLE
Remove comparisons that may cause misunderstanding(hasItemMeta())

### DIFF
--- a/main/src/main/java/me/blackvein/quests/util/ItemUtil.java
+++ b/main/src/main/java/me/blackvein/quests/util/ItemUtil.java
@@ -71,11 +71,12 @@ public class ItemUtil {
             }
         }
         if (one.hasItemMeta() || two.hasItemMeta()) {
-            if (one.hasItemMeta() && two.hasItemMeta() == false) {
-                return -4;
-            } else if (one.hasItemMeta() == false && two.hasItemMeta()) {
-                return -4;
-            } else if (one.getItemMeta().hasDisplayName() && two.getItemMeta().hasDisplayName() == false) {
+            //if (one.hasItemMeta() && two.hasItemMeta() == false) {
+            //    return -4;
+            //} else if (one.hasItemMeta() == false && two.hasItemMeta()) {
+            //    return -4;
+            //} else
+            if (one.getItemMeta().hasDisplayName() && two.getItemMeta().hasDisplayName() == false) {
                 return -4;
             } else if (one.getItemMeta().hasDisplayName() == false && two.getItemMeta().hasDisplayName()) {
                 return -4;


### PR DESCRIPTION
This will cause the specified item to be unrecognized, and a "difference: display name or lore" error will be prompted.
And, "if (xxxx == false)" is this coding style a mandatory coding style?