### PR TITLE
Add missing disable-command-feedback check

### DIFF
--- a/main/src/main/java/me/blackvein/quests/Settings.java
+++ b/main/src/main/java/me/blackvein/quests/Settings.java
@@ -176,6 +176,7 @@ public class Settings {
         allowPranks = config.getBoolean("allow-pranks", true);
         askConfirmation = config.getBoolean("ask-confirmation", true);
         consoleLogging = config.getInt("console-logging", 1);
+        disableCommandFeedback = config.getBoolean("disable-command-feedback", true);
         genFilesOnJoin = config.getBoolean("generate-files-on-join", true);
         ignoreLockedQuests = config.getBoolean("ignore-locked-quests", false);
         killDelay = config.getInt("kill-delay", 600);


### PR DESCRIPTION
The Settings file was missing a config check for the disable-command-feedback config option so it would always use the default value of true.  I've tested the change and it works.  Thanks!