### PR TITLE
Cancel hotkeying journal into inventory

### DIFF
--- a/main/src/main/java/me/blackvein/quests/listeners/PlayerListener.java
+++ b/main/src/main/java/me/blackvein/quests/listeners/PlayerListener.java
@@ -99,6 +99,7 @@ public class PlayerListener implements Listener {
             if (item!=null) {
                if (ItemUtil.isItem(item) && ItemUtil.isJournal(item)) {
                     evt.setCancelled(true);
+                   return;
                 }
             }
         }

--- a/main/src/main/java/me/blackvein/quests/listeners/PlayerListener.java
+++ b/main/src/main/java/me/blackvein/quests/listeners/PlayerListener.java
@@ -98,7 +98,7 @@ public class PlayerListener implements Listener {
             ItemStack item=evt.getWhoClicked().getInventory().getItem(event.getHotbarButton());
             if (item!=null) {
                if (ItemUtil.isItem(item) && ItemUtil.isJournal(item)) {
-                    event.setCancelled(true);
+                    evt.setCancelled(true);
                 }
             }
         }

--- a/main/src/main/java/me/blackvein/quests/listeners/PlayerListener.java
+++ b/main/src/main/java/me/blackvein/quests/listeners/PlayerListener.java
@@ -94,6 +94,13 @@ public class PlayerListener implements Listener {
                 evt.setCancelled(true);
                 return;
             }
+        } else if (ac.equals(InventoryAction.SWAP_WITH_CURSOR))) {
+            ItemStack item=evt.getWhoClicked().getInventory().getItem(event.getHotbarButton());
+            if (item!=null) {
+               if (ItemUtil.isItem(item) && ItemUtil.isJournal(item)) {
+                    event.setCancelled(true);
+                }
+            }
         }
         if (ItemUtil.isItem(evt.getCurrentItem()) && ItemUtil.isJournal(evt.getCurrentItem()) 
                 || ItemUtil.isItem(evt.getCursor()) && ItemUtil.isJournal(evt.getCursor())) {


### PR DESCRIPTION
Previously, a journal could be moved into another inventory by putting it in a hotkey slot and pressing the corresponding hotkey while hovering over any slot in the target inventory.