### PR TITLE
SQL Update (player progress)

### DIFF
--- a/main/src/main/java/me/blackvein/quests/storage/implementation/sql/SqlStorage.java
+++ b/main/src/main/java/me/blackvein/quests/storage/implementation/sql/SqlStorage.java
@@ -12,18 +12,14 @@
 
 package me.blackvein.quests.storage.implementation.sql;
 
-import me.blackvein.quests.Quest;
-import me.blackvein.quests.Quester;
-import me.blackvein.quests.Quests;
-import me.blackvein.quests.storage.implementation.StorageImplementation;
-import me.blackvein.quests.storage.implementation.sql.connection.ConnectionFactory;
-
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
@@ -31,6 +27,24 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+
+import me.blackvein.quests.Quest;
+import me.blackvein.quests.QuestData;
+import me.blackvein.quests.Quester;
+import me.blackvein.quests.Quests;
+import me.blackvein.quests.Stage;
+import me.blackvein.quests.storage.implementation.StorageImplementation;
+import me.blackvein.quests.storage.implementation.sql.connection.ConnectionFactory;
+import me.blackvein.quests.util.ConfigUtil;
+import me.blackvein.quests.util.MiscUtil;
 
 public class SqlStorage implements StorageImplementation {
     private static final String PLAYER_SELECT = "SELECT lastknownname, questpoints FROM '{prefix}players' WHERE uuid=?";
@@ -58,7 +72,10 @@ public class SqlStorage implements StorageImplementation {
     private static final String PLAYER_REDOABLE_QUESTS_INSERT = "INSERT INTO '{prefix}player_redoablequests' (uuid, questid, lasttime, amount) "
             + "VALUES(?, ?, ?, ?) ON DUPLICATE KEY UPDATE uuid=uuid, questid=questid, lasttime=VALUES(lasttime), amount=VALUES(amount)";
     private static final String PLAYER_REDOABLE_QUESTS_DELETE = "DELETE FROM '{prefix}player_redoablequests' WHERE uuid=?";
-
+    private static final String PLAYER_QUESTDATA_SELECT = "SELECT data FROM '{prefix}player_questdata' WHERE uuid=?";
+    private static final String PLAYER_QUESTDATA_INSERT = "INSERT INTO '{prefix}player_questdata' (uuid,data) VALUES(?,?) "
+            + "ON DUPLICATE KEY UPDATE uuid=?, data=?";
+    private static final String PLAYER_QUESTDATA_DELETE = "DELETE FROM '{prefix}player_questdata' WHERE uuid=?";
     private final Quests plugin;
     private final ConnectionFactory connectionFactory;
     private final Function<String, String> statementProcessor;
@@ -92,7 +109,7 @@ public class SqlStorage implements StorageImplementation {
         connectionFactory.init(plugin);
         
         try (Connection c = connectionFactory.getConnection()) {
-            final String[] queries = new String[4];
+            final String[] queries = new String[5];
             queries[0] = "CREATE TABLE IF NOT EXISTS `" + statementProcessor.apply("{prefix}players") 
                     + "` (`uuid` VARCHAR(36) NOT NULL, "
                     + "`lastknownname` VARCHAR(16) NOT NULL, "
@@ -123,6 +140,9 @@ public class SqlStorage implements StorageImplementation {
                     + "PRIMARY KEY (`id`),"
                     + "UNIQUE KEY (`uuid`, `questid`)"
                     + ") DEFAULT CHARSET = utf8mb4";
+            queries[4] = "CREATE TABLE IF NOT EXISTS `" + statementProcessor.apply("{prefix}player_questdata")  
+            		     + "` (`uuid` VARCHAR(36) NOT NULL,"
+            		     + "`data` VARCHAR(8000) NOT NULL,PRIMARY KEY(`uuid`)) DEFAULT CHARSET = utf8mb4";
             try (Statement s = c.createStatement()) {
                 for (final String query : queries) {
                     try {
@@ -131,6 +151,7 @@ public class SqlStorage implements StorageImplementation {
                         if (e.getMessage().contains("Unknown character set")) {
                             s.execute(query.replace("utf8mb4", "utf8"));
                         } else {
+                        	e.printStackTrace();
                             throw e;
                         }
                     }
@@ -170,6 +191,7 @@ public class SqlStorage implements StorageImplementation {
                 quester.setCompletedQuests(getQuesterCompletedQuests(uniqueId));
                 quester.setCompletedTimes(getQuesterCompletedTimes(uniqueId));
                 quester.setAmountsCompleted(getQuesterAmountsCompleted(uniqueId));
+                getQuestData(uniqueId);
             }
         }
         return quester;
@@ -189,8 +211,10 @@ public class SqlStorage implements StorageImplementation {
         final Set<String> redoableQuests = quester.getCompletedTimes().keySet().stream().map(Quest::getId).collect(Collectors.toSet());
         final Set<String> oldRedoableQuests = getQuesterCompletedTimes(uniqueId).keySet().stream().map(Quest::getId).collect(Collectors.toSet());
         oldRedoableQuests.removeAll(redoableQuests);
+        final ConcurrentHashMap<Quest,QuestData> questdata = quester.getQuestData();
         
         try (final Connection c = connectionFactory.getConnection()) {
+        	
             if (oldLastKnownName != null && lastKnownName != null && !lastKnownName.equals(oldLastKnownName)) {
                 try (PreparedStatement ps = c.prepareStatement(statementProcessor.apply(PLAYER_UPDATE_USERNAME))) {
                     ps.setString(1, lastKnownName);
@@ -263,6 +287,18 @@ public class SqlStorage implements StorageImplementation {
                     }
                 }
             }
+            
+            if(!questdata.isEmpty()) {
+            	try(PreparedStatement ps = c.prepareStatement(statementProcessor.apply(PLAYER_QUESTDATA_INSERT))){
+            		ps.setString(1, uniqueId.toString());
+            		FileConfiguration config = quester.getBaseData();
+            		String s = ((YamlConfiguration)config).saveToString();
+            		ps.setString(2, s);
+            		ps.setString(3, uniqueId.toString());
+            		ps.setString(4, s);
+            		ps.execute();
+            	}
+            }
         }
     }
 
@@ -284,6 +320,10 @@ public class SqlStorage implements StorageImplementation {
             try (PreparedStatement ps = c.prepareStatement(statementProcessor.apply(PLAYER_REDOABLE_QUESTS_DELETE))) {
                 ps.setString(1, uniqueId.toString());
                 ps.execute();
+            }
+            try(PreparedStatement ps = c.prepareStatement(statementProcessor.apply(PLAYER_QUESTDATA_DELETE))){
+            	ps.setString(1, uniqueId.toString());
+            	ps.execute();
             }
         }
     }
@@ -319,6 +359,361 @@ public class SqlStorage implements StorageImplementation {
             }
         }
         return currentQuests;
+    }
+    
+    @SuppressWarnings("deprecation")
+	public void getQuestData(final UUID uniqueId) throws Exception {
+    	Quester quester = this.plugin.getQuester(uniqueId);
+    	if(quester == null) {
+    
+    	}
+    	try(Connection c = connectionFactory.getConnection()){
+    		try(PreparedStatement ps = c.prepareStatement(statementProcessor.apply(PLAYER_QUESTDATA_SELECT))){
+    			ps.setString(1, uniqueId.toString());
+    		  ResultSet rs = ps.executeQuery();
+    		  if(rs.next()) {
+    			  String raw = rs.getString("data");
+    			  YamlConfiguration yml = new YamlConfiguration();
+    			  yml.loadFromString(raw);
+    	            final ConfigurationSection dataSec = yml.getConfigurationSection("questData");
+    	            if (dataSec == null || dataSec.getKeys(false).isEmpty()) {
+    	                return;
+    	            }
+    	            for (final String key : dataSec.getKeys(false)) {
+    	                final ConfigurationSection questSec = dataSec.getConfigurationSection(key);
+    	                final Quest quest = plugin.getQuestById(key) != null ? plugin.getQuestById(key) : plugin.getQuest(key);
+    	                Stage stage;
+    	                if (quest == null || quester.getCurrentQuests().containsKey(quest) == false) {
+    	                    continue;
+    	                }
+    	                stage = quester.getCurrentStage(quest);
+    	                if (stage == null) {
+    	                    quest.completeQuest(quester);
+    	                    plugin.getLogger().severe("[Quests] Invalid stage number for player: \"" + uniqueId + "\" on Quest \"" 
+    	                            + quest.getName() + "\". Quest ended.");
+    	                    continue;
+    	                }
+    	                quester.addEmptiesFor(quest, quester.getCurrentQuests().get(quest));
+    	                if (questSec == null) {
+    	                    continue;
+    	                }
+    	                if (questSec.contains("blocks-broken-names")) {
+    	                    final List<String> names = questSec.getStringList("blocks-broken-names");
+    	                    final List<Integer> amounts = questSec.getIntegerList("blocks-broken-amounts");
+    	                    final List<Short> durability = questSec.getShortList("blocks-broken-durability");
+    	                    int index = 0;
+    	                    for (final String s : names) {
+    	                        ItemStack is;
+    	                        try {
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), durability.get(index));
+    	                        } catch (final IndexOutOfBoundsException e) {
+    	                            // Legacy
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), (short) 0);
+    	                        }
+    	                        if (quester.getQuestData(quest).blocksBroken.size() > 0) {
+    	                            quester.getQuestData(quest).blocksBroken.set(index, is);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("blocks-damaged-names")) {
+    	                    final List<String> names = questSec.getStringList("blocks-damaged-names");
+    	                    final List<Integer> amounts = questSec.getIntegerList("blocks-damaged-amounts");
+    	                    final List<Short> durability = questSec.getShortList("blocks-damaged-durability");
+    	                    int index = 0;
+    	                    for (final String s : names) {
+    	                        ItemStack is;
+    	                        try {
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), durability.get(index));
+    	                        } catch (final IndexOutOfBoundsException e) {
+    	                            // Legacy
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), (short) 0);
+    	                        }
+    	                        if (quester.getQuestData(quest).blocksDamaged.size() > 0) {
+    	                            quester.getQuestData(quest).blocksDamaged.set(index, is);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("blocks-placed-names")) {
+    	                    final List<String> names = questSec.getStringList("blocks-placed-names");
+    	                    final List<Integer> amounts = questSec.getIntegerList("blocks-placed-amounts");
+    	                    final List<Short> durability = questSec.getShortList("blocks-placed-durability");
+    	                    int index = 0;
+    	                    for (final String s : names) {
+    	                        ItemStack is;
+    	                        try {
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), durability.get(index));
+    	                        } catch (final IndexOutOfBoundsException e) {
+    	                            // Legacy
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), (short) 0);
+    	                        }
+    	                        if (quester.getQuestData(quest).blocksPlaced.size() > 0) {
+    	                            quester.getQuestData(quest).blocksPlaced.set(index, is);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("blocks-used-names")) {
+    	                    final List<String> names = questSec.getStringList("blocks-used-names");
+    	                    final List<Integer> amounts = questSec.getIntegerList("blocks-used-amounts");
+    	                    final List<Short> durability = questSec.getShortList("blocks-used-durability");
+    	                    int index = 0;
+    	                    for (final String s : names) {
+    	                        ItemStack is;
+    	                        try {
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), durability.get(index));
+    	                        } catch (final IndexOutOfBoundsException e) {
+    	                            // Legacy
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), (short) 0);
+    	                        }
+    	                        if (quester.getQuestData(quest).blocksUsed.size() > 0) {
+    	                            quester.getQuestData(quest).blocksUsed.set(index, is);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("blocks-cut-names")) {
+    	                    final List<String> names = questSec.getStringList("blocks-cut-names");
+    	                    final List<Integer> amounts = questSec.getIntegerList("blocks-cut-amounts");
+    	                    final List<Short> durability = questSec.getShortList("blocks-cut-durability");
+    	                    int index = 0;
+    	                    for (final String s : names) {
+    	                        ItemStack is;
+    	                        try {
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), durability.get(index));
+    	                        } catch (final IndexOutOfBoundsException e) {
+    	                            // Legacy
+    	                            is = new ItemStack(Material.matchMaterial(s), amounts.get(index), (short) 0);
+    	                        }
+    	                        if (quester.getQuestData(quest).blocksCut.size() > 0) {
+    	                            quester.getQuestData(quest).blocksCut.set(index, is);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("item-craft-amounts")) {
+    	                    final List<Integer> craftAmounts = questSec.getIntegerList("item-craft-amounts");
+    	                    int index = 0;
+    	                    for (final int amt : craftAmounts) {
+    	                        final ItemStack is = quester.getCurrentStage(quest).getItemsToCraft().get(index);
+    	                        final ItemStack temp = is.clone();
+    	                        temp.setAmount(amt);
+    	                        if (quester.getQuestData(quest).itemsCrafted.size() > 0) {
+    	                            quester.getQuestData(quest).itemsCrafted.set(index, temp);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("item-smelt-amounts")) {
+    	                    final List<Integer> smeltAmounts = questSec.getIntegerList("item-smelt-amounts");
+    	                    int index = 0;
+    	                    for (final int amt : smeltAmounts) {
+    	                        final ItemStack is = quester.getCurrentStage(quest).getItemsToSmelt().get(index);
+    	                        final ItemStack temp = is.clone();
+    	                        temp.setAmount(amt);
+    	                        if (quester.getQuestData(quest).itemsSmelted.size() > 0) {
+    	                            quester.getQuestData(quest).itemsSmelted.set(index, temp);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("item-enchant-amounts")) {
+    	                    final List<Integer> enchantAmounts = questSec.getIntegerList("item-enchant-amounts");
+    	                    int index = 0;
+    	                    for (final int amt : enchantAmounts) {
+    	                        final ItemStack is = quester.getCurrentStage(quest).getItemsToEnchant().get(index);
+    	                        final ItemStack temp = is.clone();
+    	                        temp.setAmount(amt);
+    	                        if (quester.getQuestData(quest).itemsEnchanted.size() > 0) {
+    	                            quester.getQuestData(quest).itemsEnchanted.set(index, temp);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("item-brew-amounts")) {
+    	                    final List<Integer> brewAmounts = questSec.getIntegerList("item-brew-amounts");
+    	                    int index = 0;
+    	                    for (final int amt : brewAmounts) {
+    	                        final ItemStack is = quester.getCurrentStage(quest).getItemsToBrew().get(index);
+    	                        final ItemStack temp = is.clone();
+    	                        temp.setAmount(amt);
+    	                        if (quester.getQuestData(quest).itemsBrewed.size() > 0) {
+    	                            quester.getQuestData(quest).itemsBrewed.set(index, temp);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("item-consume-amounts")) {
+    	                    final List<Integer> consumeAmounts = questSec.getIntegerList("item-consume-amounts");
+    	                    int index = 0;
+    	                    for (final int amt : consumeAmounts) {
+    	                        final ItemStack is = quester.getCurrentStage(quest).getItemsToConsume().get(index);
+    	                        final ItemStack temp = is.clone();
+    	                        temp.setAmount(amt);
+    	                        if (quester.getQuestData(quest).itemsConsumed.size() > 0) {
+    	                            quester.getQuestData(quest).itemsConsumed.set(index, temp);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                
+    	                if (questSec.contains("item-delivery-amounts")) {
+    	                    final List<Integer> deliveryAmounts = questSec.getIntegerList("item-delivery-amounts");
+    	                    int index = 0;
+    	                    for (final int amt : deliveryAmounts) {
+    	                        final ItemStack is = quester.getCurrentStage(quest).getItemsToDeliver().get(index);
+    	                        final ItemStack temp = new ItemStack(is.getType(), amt, is.getDurability());
+    	                        temp.addUnsafeEnchantments(is.getEnchantments());
+    	                        temp.setItemMeta(is.getItemMeta());
+    	                        if (quester.getQuestData(quest).itemsDelivered.size() > 0) {
+    	                            quester.getQuestData(quest).itemsDelivered.set(index, temp);
+    	                        }
+    	                        index++;
+    	                    }
+    	                }
+    	                if (questSec.contains("citizen-ids-to-talk-to")) {
+    	                    final List<Integer> ids = questSec.getIntegerList("citizen-ids-to-talk-to");
+    	                    final List<Boolean> has = questSec.getBooleanList("has-talked-to");
+    	                    for (final int i : ids) {
+    	                        quester.getQuestData(quest).citizensInteracted.put(i, has.get(ids.indexOf(i)));
+    	                    }
+    	                }
+    	                if (questSec.contains("citizen-ids-killed")) {
+    	                    final List<Integer> ids = questSec.getIntegerList("citizen-ids-killed");
+    	                    final List<Integer> num = questSec.getIntegerList("citizen-amounts-killed");
+    	                    quester.getQuestData(quest).citizensKilled.clear();
+    	                    quester.getQuestData(quest).citizenNumKilled.clear();
+    	                    for (final int i : ids) {
+    	                        quester.getQuestData(quest).citizensKilled.add(i);
+    	                        quester.getQuestData(quest).citizenNumKilled.add(num.get(ids.indexOf(i)));
+    	                    }
+    	                }
+    	                if (questSec.contains("cows-milked")) {
+    	                    quester.getQuestData(quest).setCowsMilked(questSec.getInt("cows-milked"));
+    	                }
+    	                if (questSec.contains("fish-caught")) {
+    	                    quester.getQuestData(quest).setFishCaught(questSec.getInt("fish-caught"));
+    	                }
+    	                if (questSec.contains("players-killed")) {
+    	                    quester.getQuestData(quest).setPlayersKilled(questSec.getInt("players-killed"));
+    	                }
+    	                if (questSec.contains("mobs-killed")) {
+    	                    final LinkedList<EntityType> mobs = new LinkedList<EntityType>();
+    	                    final List<Integer> amounts = questSec.getIntegerList("mobs-killed-amounts");
+    	                    for (final String s : questSec.getStringList("mobs-killed")) {
+    	                        final EntityType mob = MiscUtil.getProperMobType(s);
+    	                        if (mob != null) {
+    	                            mobs.add(mob);
+    	                        }
+    	                        quester.getQuestData(quest).mobsKilled.clear();
+    	                        quester.getQuestData(quest).mobNumKilled.clear();
+    	                        for (final EntityType e : mobs) {
+    	                            quester.getQuestData(quest).mobsKilled.add(e);
+    	                            quester.getQuestData(quest).mobNumKilled.add(amounts.get(mobs.indexOf(e)));
+    	                        }
+    	                        if (questSec.contains("mob-kill-locations")) {
+    	                            final LinkedList<Location> locations = new LinkedList<Location>();
+    	                            final List<Integer> radii = questSec.getIntegerList("mob-kill-location-radii");
+    	                            for (final String loc : questSec.getStringList("mob-kill-locations")) {
+    	                                if (ConfigUtil.getLocation(loc) != null) {
+    	                                    locations.add(ConfigUtil.getLocation(loc));
+    	                                }
+    	                            }
+    	                            quester.getQuestData(quest).locationsToKillWithin = locations;
+    	                            quester.getQuestData(quest).radiiToKillWithin.clear();
+    	                            for (final int i : radii) {
+    	                                quester.getQuestData(quest).radiiToKillWithin.add(i);
+    	                            }
+    	                        }
+    	                    }
+    	                }
+    	                if (questSec.contains("locations-to-reach")) {
+    	                    final LinkedList<Location> locations = new LinkedList<Location>();
+    	                    final List<Boolean> has = questSec.getBooleanList("has-reached-location");
+    	                    while (has.size() < locations.size()) {
+    	                        // TODO - Find proper cause of Github issues #646 and #825
+    	                        plugin.getLogger().info("Added missing has-reached-location data for Quester " + uniqueId);
+    	                        has.add(false);
+    	                    }
+    	                    final List<Integer> radii = questSec.getIntegerList("radii-to-reach-within");
+    	                    for (final String loc : questSec.getStringList("locations-to-reach")) {
+    	                        if (ConfigUtil.getLocation(loc) != null) {
+    	                            locations.add(ConfigUtil.getLocation(loc));
+    	                        }
+    	                    }
+    	                    quester.getQuestData(quest).locationsReached = locations;
+    	                    quester.getQuestData(quest).hasReached.clear();
+    	                    quester.getQuestData(quest).radiiToReachWithin.clear();
+    	                    for (final boolean b : has) {
+    	                        quester.getQuestData(quest).hasReached.add(b);
+    	                    }
+    	                    for (final int i : radii) {
+    	                        quester.getQuestData(quest).radiiToReachWithin.add(i);
+    	                    }
+    	                }
+    	                if (questSec.contains("mobs-to-tame")) {
+    	                    final List<String> mobs = questSec.getStringList("mobs-to-tame");
+    	                    final List<Integer> amounts = questSec.getIntegerList("mob-tame-amounts");
+    	                    for (final String mob : mobs) {
+    	                        quester.getQuestData(quest).mobsTamed.put(EntityType.valueOf(mob.toUpperCase()), amounts
+    	                                .get(mobs.indexOf(mob)));
+    	                    }
+    	                }
+    	                if (questSec.contains("sheep-to-shear")) {
+    	                    final List<String> colors = questSec.getStringList("sheep-to-shear");
+    	                    final List<Integer> amounts = questSec.getIntegerList("sheep-sheared");
+    	                    for (final String color : colors) {
+    	                        quester.getQuestData(quest).sheepSheared.put(MiscUtil.getProperDyeColor(color), amounts.get(colors
+    	                                .indexOf(color)));
+    	                    }
+    	                }
+    	                if (questSec.contains("passwords")) {
+    	                    final List<String> passwords = questSec.getStringList("passwords");
+    	                    final List<Boolean> said = questSec.getBooleanList("passwords-said");
+    	                    for (int i = 0; i < passwords.size(); i++) {
+    	                        quester.getQuestData(quest).passwordsSaid.put(passwords.get(i), said.get(i));
+    	                    }
+    	                }
+    	                if (questSec.contains("custom-objectives")) {
+    	                    final List<String> customObj = questSec.getStringList("custom-objectives");
+    	                    final List<Integer> customObjCount = questSec.getIntegerList("custom-objective-counts");
+    	                    for (int i = 0; i < customObj.size(); i++) {
+    	                        quester.getQuestData(quest).customObjectiveCounts.put(customObj.get(i), customObjCount.get(i));
+    	                    }
+    	                }
+    	                if (questSec.contains("stage-delay")) {
+    	                    quester.getQuestData(quest).setDelayTimeLeft(questSec.getLong("stage-delay"));
+    	                }
+    	                if (quester.getCurrentStage(quest).getChatActions().isEmpty() == false) {
+    	                    for (final String chatTrig : quester.getCurrentStage(quest).getChatActions().keySet()) {
+    	                        quester.getQuestData(quest).actionFired.put(chatTrig, false);
+    	                    }
+    	                }
+    	                if (questSec.contains("chat-triggers")) {
+    	                    final List<String> chatTriggers = questSec.getStringList("chat-triggers");
+    	                    for (final String s : chatTriggers) {
+    	                        quester.getQuestData(quest).actionFired.put(s, true);
+    	                    }
+    	                }
+    	                if (quester.getCurrentStage(quest).getCommandActions().isEmpty() == false) {
+    	                    for (final String commandTrig : quester.getCurrentStage(quest).getCommandActions().keySet()) {
+    	                        quester.getQuestData(quest).actionFired.put(commandTrig, false);
+    	                    }
+    	                }
+    	                if (questSec.contains("command-triggers")) {
+    	                    final List<String> commandTriggers = questSec.getStringList("command-triggers");
+    	                    for (final String s : commandTriggers) {
+    	                        quester.getQuestData(quest).actionFired.put(s, true);
+    	                    }
+    	                }
+    	            }
+    			 
+    		  }else {
+    		  }
+    		}
+    	}
+	
     }
     
     public ConcurrentSkipListSet<Quest> getQuesterCompletedQuests(final UUID uniqueId) throws Exception {

--- a/main/src/main/java/me/blackvein/quests/storage/implementation/sql/SqlStorage.java
+++ b/main/src/main/java/me/blackvein/quests/storage/implementation/sql/SqlStorage.java
@@ -365,7 +365,7 @@ public class SqlStorage implements StorageImplementation {
 	public void getQuestData(final UUID uniqueId) throws Exception {
     	Quester quester = this.plugin.getQuester(uniqueId);
     	if(quester == null) {
-    
+          return;
     	}
     	try(Connection c = connectionFactory.getConnection()){
     		try(PreparedStatement ps = c.prepareStatement(statementProcessor.apply(PLAYER_QUESTDATA_SELECT))){


### PR DESCRIPTION
So as hkkongou reported that when storage implementation is selected as sql,the sql implementation does not save any questdata until they actually complete the stage/quest.This pull request aims at solving this problem,also added commands to facilitate the flexibility of the plugin on player data saving progress. For details see #1707 

Workings:
So YML implementation saves file from quester.getBaseData();
I leveraged this functionality to tried to implement this in sql environment (ie:brutally tear yml files into strings and save it into sql server)

Commands added:
-/questadmin saveall - save all questdata of the player
-/questadmin save <player> - save questdata of the particular player <player>