### PR TITLE
Add clickable prompts config option

### DIFF
--- a/api/src/main/java/me/blackvein/quests/Quests.java
+++ b/api/src/main/java/me/blackvein/quests/Quests.java
@@ -637,6 +637,11 @@ public class Quests extends JavaPlugin {
             final MiscPostQuestAcceptEvent event = new MiscPostQuestAcceptEvent(context, this);
             getServer().getPluginManager().callEvent(event);
 
+            if (!getSettings().canClickablePrompts()) {
+                return ChatColor.YELLOW + getQueryText(context) + "  " + ChatColor.GREEN
+                        + getSelectionText(context, 1) + ChatColor.RESET + " / " + getSelectionText(context, 2);
+            }
+
             final TextComponent component = new TextComponent("");
             component.addExtra(ChatColor.YELLOW + getQueryText(context) + "  " + ChatColor.GREEN);
             final TextComponent yes = new TextComponent(getSelectionText(context, 1));

--- a/api/src/main/java/me/blackvein/quests/Settings.java
+++ b/api/src/main/java/me/blackvein/quests/Settings.java
@@ -27,6 +27,7 @@ public class Settings {
     private boolean allowCommandsForNpcQuests = false;
     private boolean allowPranks = true;
     private boolean askConfirmation = true;
+    private boolean clickablePrompts = true;
     private int consoleLogging = 1;
     private boolean disableCommandFeedback = true;
     private boolean genFilesOnJoin = true;
@@ -78,6 +79,12 @@ public class Settings {
     }
     public void setAskConfirmation(final boolean askConfirmation) {
         this.askConfirmation = askConfirmation;
+    }
+    public boolean canClickablePrompts() {
+        return clickablePrompts;
+    }
+    public void setClickablePrompts(boolean clickablePrompts) {
+        this.clickablePrompts = clickablePrompts;
     }
     public int getConsoleLogging() {
         return consoleLogging;
@@ -189,6 +196,7 @@ public class Settings {
         allowCommandsForNpcQuests = config.getBoolean("allow-command-quests-with-npcs", false);
         allowPranks = config.getBoolean("allow-pranks", true);
         askConfirmation = config.getBoolean("ask-confirmation", true);
+        clickablePrompts = config.getBoolean("clickable-prompts", true);
         consoleLogging = config.getInt("console-logging", 1);
         disableCommandFeedback = config.getBoolean("disable-command-feedback", true);
         genFilesOnJoin = config.getBoolean("generate-files-on-join", true);

--- a/api/src/main/java/me/blackvein/quests/convo/QuestsNumericPrompt.java
+++ b/api/src/main/java/me/blackvein/quests/convo/QuestsNumericPrompt.java
@@ -15,12 +15,13 @@ package me.blackvein.quests.convo;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
-import org.bukkit.conversations.Conversable;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.NumericPrompt;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
+
+import me.blackvein.quests.Quests;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,7 +47,7 @@ public abstract class QuestsNumericPrompt extends NumericPrompt {
     
     @Override
     public @NotNull String getPromptText(@NotNull final ConversationContext cc) {
-        return sendClickableSelection(getBasicPromptText(cc), cc.getForWhom());
+        return sendClickableSelection(getBasicPromptText(cc), cc);
     }
     
     public abstract String getBasicPromptText(ConversationContext cc);
@@ -58,11 +59,11 @@ public abstract class QuestsNumericPrompt extends NumericPrompt {
      * Conversations API.
      * 
      * @param input   the Quests-styled conversation interface
-     * @param forWhom the conversation participant 
+     * @param context the conversation context
      * @return        plain text to deliver
      */
-    public static String sendClickableSelection(final String input, final Conversable forWhom) {
-        if (!(forWhom instanceof Player)) {
+    public static String sendClickableSelection(final String input, final ConversationContext context) {
+        if (!(context.getForWhom() instanceof Player) || !((Quests)context.getPlugin()).getSettings().canClickablePrompts()) {
             return input;
         }
         final String[] basicText = input.split("\n");
@@ -81,7 +82,7 @@ public abstract class QuestsNumericPrompt extends NumericPrompt {
             }
             component.addExtra(lineComponent);
         }
-        ((Player)forWhom).spigot().sendMessage(component);
+        ((Player)context.getForWhom()).spigot().sendMessage(component);
         return "";
     }
 }

--- a/api/src/main/java/me/blackvein/quests/convo/QuestsStringPrompt.java
+++ b/api/src/main/java/me/blackvein/quests/convo/QuestsStringPrompt.java
@@ -15,10 +15,13 @@ package me.blackvein.quests.convo;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.conversations.Conversable;
+
+import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.StringPrompt;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
+
+import me.blackvein.quests.Quests;
 
 import java.util.List;
 
@@ -49,12 +52,12 @@ public abstract class QuestsStringPrompt extends StringPrompt {
      * @param header  the menu header
      * @param list    a list of strings to display
      * @param footer  the menu footer
-     * @param forWhom the conversation participant
+     * @param context the conversation context
      * @return        plain text to deliver
      */
     protected String sendClickableMenu(final String header, final List<String> list, final String footer,
-                                       final Conversable forWhom) {
-        if (!(forWhom instanceof Player)) {
+                                       final ConversationContext context) {
+        if (!(context.getForWhom() instanceof Player) || !((Quests)context.getPlugin()).getSettings().canClickablePrompts()) {
             return ChatColor.GOLD + header + "\n" + ChatColor.AQUA + String.join(ChatColor.GRAY + ", " + ChatColor.AQUA, list) + "\n" + ChatColor.YELLOW + footer;
         }
         final TextComponent component = new TextComponent(header + "\n");
@@ -73,7 +76,7 @@ public abstract class QuestsStringPrompt extends StringPrompt {
             }
         }
         component.addExtra(footerComponent);
-        ((Player)forWhom).spigot().sendMessage(component);
+        ((Player)context.getForWhom()).spigot().sendMessage(component);
         return "";
     }
 }

--- a/api/src/main/java/me/blackvein/quests/convo/actions/main/ActionMainPrompt.java
+++ b/api/src/main/java/me/blackvein/quests/convo/actions/main/ActionMainPrompt.java
@@ -1084,7 +1084,7 @@ public class ActionMainPrompt extends ActionsEditorNumericPrompt {
                 text.append("\n").append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i)
                         .append(ChatColor.RESET).append(" - ").append(getSelectionText(context, i));
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override
@@ -1164,7 +1164,7 @@ public class ActionMainPrompt extends ActionsEditorNumericPrompt {
             for (int i = 1; i <= size; i++) {
                 text.append("\n").append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i).append(ChatColor.RESET).append(" - ").append(getSelectionText(context, i));
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override

--- a/api/src/main/java/me/blackvein/quests/convo/actions/menu/ActionMenuPrompt.java
+++ b/api/src/main/java/me/blackvein/quests/convo/actions/menu/ActionMenuPrompt.java
@@ -238,7 +238,7 @@ public class ActionMenuPrompt extends ActionsEditorNumericPrompt {
                     = new ActionsEditorPostOpenStringPromptEvent(context, this);
             plugin.getServer().getPluginManager().callEvent(event);
             final List<String> names = plugin.getLoadedActions().stream().map(Action::getName).collect(Collectors.toList());
-            return sendClickableMenu(getTitle(context), names, getQueryText(context), context.getForWhom());
+            return sendClickableMenu(getTitle(context), names, getQueryText(context), context);
         }
 
         @Override
@@ -284,7 +284,7 @@ public class ActionMenuPrompt extends ActionsEditorNumericPrompt {
                     = new ActionsEditorPostOpenStringPromptEvent(context, this);
             plugin.getServer().getPluginManager().callEvent(event);
             final List<String> names = plugin.getLoadedActions().stream().map(Action::getName).collect(Collectors.toList());
-            return sendClickableMenu(getTitle(context), names, getQueryText(context), context.getForWhom());
+            return sendClickableMenu(getTitle(context), names, getQueryText(context), context);
         }
 
         @Override
@@ -383,7 +383,7 @@ public class ActionMenuPrompt extends ActionsEditorNumericPrompt {
                 text.append("\n").append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i)
                         .append(ChatColor.RESET).append(" - ").append(getSelectionText(context, i));
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override

--- a/api/src/main/java/me/blackvein/quests/convo/conditions/main/ConditionMainPrompt.java
+++ b/api/src/main/java/me/blackvein/quests/convo/conditions/main/ConditionMainPrompt.java
@@ -551,7 +551,7 @@ public class ConditionMainPrompt extends ConditionsEditorNumericPrompt {
                 text.append("\n").append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i)
                         .append(ChatColor.RESET).append(" - ").append(getSelectionText(context, i));
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override
@@ -632,7 +632,7 @@ public class ConditionMainPrompt extends ConditionsEditorNumericPrompt {
                 text.append("\n").append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i)
                         .append(ChatColor.RESET).append(" - ").append(getSelectionText(context, i));
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override

--- a/api/src/main/java/me/blackvein/quests/convo/conditions/menu/ConditionMenuPrompt.java
+++ b/api/src/main/java/me/blackvein/quests/convo/conditions/menu/ConditionMenuPrompt.java
@@ -237,7 +237,7 @@ public class ConditionMenuPrompt extends ConditionsEditorNumericPrompt {
                     = new ConditionsEditorPostOpenStringPromptEvent(context, this);
             plugin.getServer().getPluginManager().callEvent(event);
             final List<String> names = plugin.getLoadedConditions().stream().map(Condition::getName).collect(Collectors.toList());
-            return sendClickableMenu(getTitle(context), names, getQueryText(context), context.getForWhom());
+            return sendClickableMenu(getTitle(context), names, getQueryText(context), context);
         }
 
         @Override
@@ -283,7 +283,7 @@ public class ConditionMenuPrompt extends ConditionsEditorNumericPrompt {
                     = new ConditionsEditorPostOpenStringPromptEvent(context, this);
             plugin.getServer().getPluginManager().callEvent(event);
             final List<String> names = plugin.getLoadedConditions().stream().map(Condition::getName).collect(Collectors.toList());
-            return sendClickableMenu(getTitle(context), names, getQueryText(context), context.getForWhom());
+            return sendClickableMenu(getTitle(context), names, getQueryText(context), context);
         }
 
         @Override
@@ -382,7 +382,7 @@ public class ConditionMenuPrompt extends ConditionsEditorNumericPrompt {
                 text.append("\n").append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i)
                         .append(ChatColor.RESET).append(" - ").append(getSelectionText(context, i));
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override

--- a/api/src/main/java/me/blackvein/quests/convo/quests/main/QuestMainPrompt.java
+++ b/api/src/main/java/me/blackvein/quests/convo/quests/main/QuestMainPrompt.java
@@ -839,7 +839,7 @@ public class QuestMainPrompt extends QuestsEditorNumericPrompt {
                 text.append("\n").append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i)
                         .append(ChatColor.RESET).append(" - ").append(getSelectionText(context, i));
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override
@@ -963,7 +963,7 @@ public class QuestMainPrompt extends QuestsEditorNumericPrompt {
                 text.append("\n").append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i)
                         .append(ChatColor.RESET).append(" - ").append(getSelectionText(context, i));
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override

--- a/api/src/main/java/me/blackvein/quests/convo/quests/menu/QuestMenuPrompt.java
+++ b/api/src/main/java/me/blackvein/quests/convo/quests/menu/QuestMenuPrompt.java
@@ -223,7 +223,7 @@ public class QuestMenuPrompt extends QuestsEditorNumericPrompt {
                     = new QuestsEditorPostOpenStringPromptEvent(context, this);
             plugin.getServer().getPluginManager().callEvent(event);
             final List<String> names = plugin.getLoadedQuests().stream().map(Quest::getName).collect(Collectors.toList());
-            return sendClickableMenu(getTitle(context), names, getQueryText(context), context.getForWhom());
+            return sendClickableMenu(getTitle(context), names, getQueryText(context), context);
         }
 
         @Override
@@ -266,7 +266,7 @@ public class QuestMenuPrompt extends QuestsEditorNumericPrompt {
                     = new QuestsEditorPostOpenStringPromptEvent(context, this);
             plugin.getServer().getPluginManager().callEvent(event);
             final List<String> names = plugin.getLoadedQuests().stream().map(Quest::getName).collect(Collectors.toList());
-            return sendClickableMenu(getTitle(context), names, getQueryText(context), context.getForWhom());
+            return sendClickableMenu(getTitle(context), names, getQueryText(context), context);
         }
 
         @Override
@@ -364,7 +364,7 @@ public class QuestMenuPrompt extends QuestsEditorNumericPrompt {
                 text.append("\n").append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i)
                         .append(ChatColor.RESET).append(" - ").append(getSelectionText(context, i));
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override

--- a/api/src/main/java/me/blackvein/quests/convo/quests/stages/StageMainPrompt.java
+++ b/api/src/main/java/me/blackvein/quests/convo/quests/stages/StageMainPrompt.java
@@ -2342,7 +2342,7 @@ public class StageMainPrompt extends QuestsEditorNumericPrompt {
                 text.append(getNumberColor(context, i)).append(ChatColor.BOLD).append(i).append(ChatColor.RESET)
                         .append(" - ").append(getSelectionText(context, i)).append("\n");
             }
-            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context.getForWhom());
+            return QuestsNumericPrompt.sendClickableSelection(text.toString(), context);
         }
 
         @Override

--- a/api/src/main/resources/config.yml
+++ b/api/src/main/resources/config.yml
@@ -5,6 +5,7 @@ allow-command-quests-with-npcs: false
 allow-pranks: true
 allow-quitting: true
 ask-confirmation: true
+clickable-prompts: true
 console-logging: 2
 disable-command-feedback: false
 generate-files-on-join: true


### PR DESCRIPTION
### Summary

This PR adds a config option, `clickable-prompts`, that determines whether prompts offered in the Quests editor and Quest accept message should be clickable. Requested in #1846. It's enabled by default.

### Notes

The config option won't add itself to an existing config, and I'm not sure what would be the preferred way of doing that (or just saying regenerate your config.)

The [Configuration](https://pikamug.gitbook.io/quests/setup/configuration) documentation will need to be updated, but I don't know how to do that.

I tested it briefly and it seemed to be working.