### PR TITLE
Delayed player data load and sync

### DIFF
--- a/core/src/main/java/me/blackvein/quests/listeners/PlayerListener.java
+++ b/core/src/main/java/me/blackvein/quests/listeners/PlayerListener.java
@@ -862,6 +862,13 @@ public class PlayerListener implements Listener {
                 noobCheck.saveData();
             }
 
+        }
+    }
+
+    @EventHandler
+    public void onPlayerJoin(final PlayerJoinEvent evt) {
+        final Player player = evt.getPlayer();
+        
             plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
                 final CompletableFuture<IQuester> cf = plugin.getStorage().loadQuester(player.getUniqueId());
                 try {
@@ -895,13 +902,7 @@ public class PlayerListener implements Listener {
                 } catch (final Exception e) {
                     e.printStackTrace();
                 }
-            });
-        }
-    }
-
-    @EventHandler
-    public void onPlayerJoin(final PlayerJoinEvent evt) {
-        final Player player = evt.getPlayer();
+            },20L);
         if (player.hasPermission("quests.admin.update")) {
             new UpdateChecker(plugin, 3711).getVersion(version -> {
                 if (!plugin.getDescription().getVersion().split("-")[0].equalsIgnoreCase(version)) {


### PR DESCRIPTION
This pull request is tested in sql bungeecord environment, evidence will ensue.

It fixes the sql issue mentioned where data across multiple bungeecord servers synced with sql (hikari) will be lost, with the immediate player data load

This Pull Request fixes the issue by delaying the player data load by 20 ticks (1 second), and this delayed data load will have to be postponed to playerjoinevent under this circumstance (since spigot/bukkit doesnt allow the creation of async delayed task in player login stage for some reason)

(sorry for the multiple instances of one pull request, because the github pull request feature is so hard to use)

