### PR TITLE
Update to use 1.21 Spigot API

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19.4-R0.1-SNAPSHOT</version>
+            <version>1.21-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/core/src/main/java/me/pikamug/quests/listeners/BukkitItemListener.java
+++ b/core/src/main/java/me/pikamug/quests/listeners/BukkitItemListener.java
@@ -216,19 +216,12 @@ public class BukkitItemListener implements Listener {
     }
 
     public boolean isWaterBottle(final ItemStack item) {
-        if (item == null) {
-            return false;
-        }
-        if (item.getType().equals(Material.POTION)) {
-            final PotionMeta meta = (PotionMeta) item.getItemMeta();
-            if (meta == null) {
-                return false;
-            }
-            if (meta.getBasePotionData().getType().equals(PotionType.WATER)) {
-                return true;
-            }
-        }
-        return false;
+        if (item == null || item.getType().equals(Material.POTION)) return false;
+
+        final PotionMeta meta = (PotionMeta) item.getItemMeta();
+        if (meta == null || meta.getBasePotionType()==null) return false;
+
+        return meta.getBasePotionType().equals(PotionType.WATER);
     }
     
     @EventHandler

--- a/core/src/main/java/me/pikamug/quests/nms/BukkitParticleProvider_Modern.java
+++ b/core/src/main/java/me/pikamug/quests/nms/BukkitParticleProvider_Modern.java
@@ -23,18 +23,18 @@ class BukkitParticleProvider_Modern extends BukkitParticleProvider {
     private static final Map<BukkitPreBuiltParticle, Object> PARTICLES = new HashMap<>();
 
     static {
-        PARTICLES.put(BukkitPreBuiltParticle.ENCHANT, Particle.ENCHANTMENT_TABLE);
+        PARTICLES.put(BukkitPreBuiltParticle.ENCHANT, Particle.ENCHANT);
         PARTICLES.put(BukkitPreBuiltParticle.CRIT, Particle.CRIT);
-        PARTICLES.put(BukkitPreBuiltParticle.SPELL, Particle.SPELL_INSTANT);
-        PARTICLES.put(BukkitPreBuiltParticle.MAGIC_CRIT, Particle.CRIT_MAGIC);
-        PARTICLES.put(BukkitPreBuiltParticle.MOB_SPELL, Particle.SPELL_MOB);
+        PARTICLES.put(BukkitPreBuiltParticle.SPELL, Particle.INSTANT_EFFECT);
+        PARTICLES.put(BukkitPreBuiltParticle.MAGIC_CRIT, Particle.ENCHANTED_HIT);
+        PARTICLES.put(BukkitPreBuiltParticle.MOB_SPELL, Particle.ENTITY_EFFECT);
         PARTICLES.put(BukkitPreBuiltParticle.NOTE, Particle.NOTE);
         PARTICLES.put(BukkitPreBuiltParticle.PORTAL, Particle.PORTAL);
-        PARTICLES.put(BukkitPreBuiltParticle.DUST, Particle.REDSTONE);
-        PARTICLES.put(BukkitPreBuiltParticle.WITCH, Particle.SPELL_WITCH);
-        PARTICLES.put(BukkitPreBuiltParticle.SNOWBALL, Particle.SNOWBALL);
-        PARTICLES.put(BukkitPreBuiltParticle.SPLASH, Particle.WATER_SPLASH);
-        PARTICLES.put(BukkitPreBuiltParticle.SMOKE, Particle.TOWN_AURA);
+        PARTICLES.put(BukkitPreBuiltParticle.DUST, Particle.DUST);
+        PARTICLES.put(BukkitPreBuiltParticle.WITCH, Particle.WITCH);
+        PARTICLES.put(BukkitPreBuiltParticle.SNOWBALL, Particle.ITEM_SNOWBALL);
+        PARTICLES.put(BukkitPreBuiltParticle.SPLASH, Particle.SPLASH);
+        PARTICLES.put(BukkitPreBuiltParticle.SMOKE, Particle.TRIAL_OMEN);
     }
 
     @Override


### PR DESCRIPTION
Update to support new API version.
Migrated old particle values and removed usage of deprecated method.