### PR TITLE
Improve getQuester performance

### DIFF
--- a/api/src/main/java/me/pikamug/quests/Quests.java
+++ b/api/src/main/java/me/pikamug/quests/Quests.java
@@ -65,9 +65,7 @@ public interface Quests {
 
     Set<Quester> getOnlineQuesters();
 
-    Set<Quester> getOfflineQuesters();
-
-    void setOfflineQuesters(final Collection<Quester> questers);
+    Collection<Quester> getOfflineQuesters();
 
     QuestFactory getQuestFactory();
 

--- a/api/src/main/java/me/pikamug/quests/Quests.java
+++ b/api/src/main/java/me/pikamug/quests/Quests.java
@@ -67,6 +67,10 @@ public interface Quests {
 
     Collection<Quester> getOfflineQuesters();
 
+    void addQuester(Quester q);
+
+    void removeQuester(Quester q);
+
     QuestFactory getQuestFactory();
 
     ActionFactory getActionFactory();

--- a/api/src/main/java/me/pikamug/quests/player/Quester.java
+++ b/api/src/main/java/me/pikamug/quests/player/Quester.java
@@ -30,8 +30,6 @@ public interface Quester extends Comparable<Quester> {
 
     UUID getUUID();
 
-    void setUUID(final UUID id);
-
     String getQuestIdToTake();
 
     void setQuestIdToTake(final String questIdToTake);

--- a/api/src/main/java/me/pikamug/quests/storage/QuesterStorage.java
+++ b/api/src/main/java/me/pikamug/quests/storage/QuesterStorage.java
@@ -14,10 +14,7 @@ import me.pikamug.quests.Quests;
 import me.pikamug.quests.player.Quester;
 import me.pikamug.quests.storage.implementation.QuesterStorageImpl;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -100,16 +97,16 @@ public class QuesterStorage {
         });
     }
 
-    public CompletableFuture<Set<Quester>> loadOfflineQuesters() {
-        final Set<Quester> questers = ConcurrentHashMap.newKeySet();
+    public CompletableFuture<Map<UUID, Quester>> loadOfflineQuesters() {
+        final Map<UUID, Quester> tmpQuesters = new ConcurrentHashMap<>();
         try {
             for (final UUID uniqueId : implementation.getSavedUniqueIds()) {
-                questers.add(implementation.loadQuester(uniqueId));
+                tmpQuesters.put(uniqueId, implementation.loadQuester(uniqueId));
             }
         } catch (final Exception e) {
             e.printStackTrace();
         }
-        return makeFuture(() -> questers);
+        return makeFuture(() -> tmpQuesters);
     }
 
     public CompletableFuture<Void> saveOfflineQuesters() {

--- a/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
@@ -89,7 +89,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
     private List<CustomObjective> customObjectives = new LinkedList<>();
     private List<CustomRequirement> customRequirements = new LinkedList<>();
     private List<CustomReward> customRewards = new LinkedList<>();
-    private Map<UUID, Quester> questers = new ConcurrentHashMap<>();
+    private final Map<UUID, Quester> questers = new ConcurrentHashMap<>();
     private Set<Quest> quests = ConcurrentHashMap.newKeySet();
     private Set<Action> actions = ConcurrentHashMap.newKeySet();
     private Set<Condition> conditions = ConcurrentHashMap.newKeySet();

--- a/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
@@ -89,7 +89,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
     private List<CustomObjective> customObjectives = new LinkedList<>();
     private List<CustomRequirement> customRequirements = new LinkedList<>();
     private List<CustomReward> customRewards = new LinkedList<>();
-    private final Map<UUID, Quester> questers = new ConcurrentHashMap<>();
+    private volatile Map<UUID, Quester> questers = new ConcurrentHashMap<>();
     private Set<Quest> quests = ConcurrentHashMap.newKeySet();
     private Set<Action> actions = ConcurrentHashMap.newKeySet();
     private Set<Condition> conditions = ConcurrentHashMap.newKeySet();
@@ -637,10 +637,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             }
             getServer().getScheduler().runTaskAsynchronously(this, () -> {
                 try {
-                    questers.clear();
-                    for (final Quester q : storage.loadOfflineQuesters().get()) {
-                        questers.put(q.getUUID(), q);
-                    }
+                    questers = storage.loadOfflineQuesters().get();
                 } catch (final Exception e) {
                     e.printStackTrace();
                 }

--- a/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
@@ -400,14 +400,11 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
      * @return new or existing Quester
      */
     public BukkitQuester getQuester(final @NotNull UUID id) {
-        Quester cachedQuester = questers.get(id);
-        if (cachedQuester instanceof BukkitQuester) return (BukkitQuester) cachedQuester;
+        if (depends.isNpc(id)) {
+            return new BukkitQuester(this, id);
+        }
 
-        final BukkitQuester quester = new BukkitQuester(this, id);
-        if (depends.isNpc(id)) return quester;
-
-        questers.put(id, quester);
-        return quester;
+        return (BukkitQuester) questers.computeIfAbsent(id, uuid -> new BukkitQuester(this, uuid));
     }
 
     /**

--- a/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
@@ -437,8 +437,17 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
      *
      * @param q the Quester object to be inserted or updated in the questers map
      */
-    public void upsertQuester(final Quester q) {
+    public void addQuester(final Quester q) {
         questers.put(q.getUUID(), q);
+    }
+
+    /**
+     * Removes the specified Quester from the internal storage of questers.
+     *
+     * @param q the Quester object to be removed
+     */
+    public void removeQuester(final Quester q) {
+        removeQuester(q.getUUID());
     }
 
     /**

--- a/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
+++ b/bukkit/src/main/java/me/pikamug/quests/BukkitQuestsPlugin.java
@@ -70,13 +70,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -95,7 +89,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
     private List<CustomObjective> customObjectives = new LinkedList<>();
     private List<CustomRequirement> customRequirements = new LinkedList<>();
     private List<CustomReward> customRewards = new LinkedList<>();
-    private Set<Quester> questers = ConcurrentHashMap.newKeySet();
+    private Map<UUID, Quester> questers = new ConcurrentHashMap<>();
     private Set<Quest> quests = ConcurrentHashMap.newKeySet();
     private Set<Action> actions = ConcurrentHashMap.newKeySet();
     private Set<Condition> conditions = ConcurrentHashMap.newKeySet();
@@ -165,7 +159,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             final BukkitMetrics metrics = new BukkitMetrics(this);
             metrics.addCustomChart(new BukkitMetrics.SimplePie("language", () -> configSettings.getLanguage()));
         }
-        
+
         // 4 - Setup language files
         try {
             BukkitLang.init(this);
@@ -175,10 +169,10 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
 
         // 5 - Load command executor
         cmdExecutor = new BukkitCommandManager(this);
-        
+
         // 6 - Load soft-depends
         depends.init();
-        
+
         // 7 - Transfer resources from jar
         moveStorageResource("quests.yml");
         moveStorageResource("actions.yml");
@@ -186,14 +180,14 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
         saveResourceAs("quests.yml", "storage/quests.yml", false);
         saveResourceAs("actions.yml", "storage/actions.yml", false);
         saveResourceAs("conditions.yml", "storage/conditions.yml", false);
-        
+
         // 8 - Save config with any new options
         getConfig().options().copyDefaults(true);
         getConfig().options().header("See https://pikamug.gitbook.io/quests/setup/configuration");
         saveConfig();
         final BukkitStorageFactory storageFactory = new BukkitStorageFactory(this);
         storage = storageFactory.getInstance();
-        
+
         // 9 - Setup commands
         if (getCommand("quests") != null) {
             Objects.requireNonNull(getCommand("quests")).setExecutor(getTabExecutor());
@@ -406,19 +400,14 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
      * @return new or existing Quester
      */
     public BukkitQuester getQuester(final @NotNull UUID id) {
-        final Set<Quester> set = questers;
-        for (final Quester q : set) {
-            if (q != null && q.getUUID().equals(id)) {
-                return (BukkitQuester) q;
-            }
-        }
+        Quester cachedQuester = questers.get(id);
+        if (cachedQuester instanceof BukkitQuester) return (BukkitQuester) cachedQuester;
+
         final BukkitQuester quester = new BukkitQuester(this, id);
-        if (depends.isNpc(id)) {
-            return quester;
-        }
-        final BukkitQuester q = new BukkitQuester(this, id);
-        questers.add(q);
-        return q;
+        if (depends.isNpc(id)) return quester;
+
+        questers.put(id, quester);
+        return quester;
     }
 
     /**
@@ -437,23 +426,31 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
     }
 
     /**
-     * Get every Quester that has ever played on this server
+     * Retrieves all offline Questers currently stored in memory.
      *
-     * @return a set of all Questers
+     * @return an unmodifiable collection of all offline Questers
      */
-    public Set<Quester> getOfflineQuesters() {
-        return questers;
+    public Collection<Quester> getOfflineQuesters() {
+        return Collections.unmodifiableCollection(questers.values());
     }
 
     /**
-     * Set every Quester that has ever played on this server
+     * Inserts or updates the provided Quester object into the questers map,
+     * using the Quester's UUID as the key.
      *
-     * @param questers a set of Questers
+     * @param q the Quester object to be inserted or updated in the questers map
      */
-    public void setOfflineQuesters(final Collection<Quester> questers) {
-        final Set<Quester> newQuesters = ConcurrentHashMap.newKeySet();
-        newQuesters.addAll(questers);
-        this.questers = newQuesters;
+    public void upsertQuester(final Quester q) {
+        questers.put(q.getUUID(), q);
+    }
+
+    /**
+     * Removes a Quester associated with the specified UUID from the internal storage of questers.
+     *
+     * @param id the UUID of the Quester to be removed
+     */
+    public void removeQuester(final UUID id) {
+        questers.remove(id);
     }
 
     /**
@@ -643,7 +640,10 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             }
             getServer().getScheduler().runTaskAsynchronously(this, () -> {
                 try {
-                    questers = storage.loadOfflineQuesters().get();
+                    questers.clear();
+                    for (final Quester q : storage.loadOfflineQuesters().get()) {
+                        questers.put(q.getUUID(), q);
+                    }
                 } catch (final Exception e) {
                     e.printStackTrace();
                 }
@@ -652,12 +652,12 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
         getServer().getScheduler().scheduleSyncDelayedTask(this, () -> {
             // Workaround for issues with the Compass on fast join
             for (final Player p : getServer().getOnlinePlayers()) {
-                final Quester quester =  new BukkitQuester(BukkitQuestsPlugin.this, p.getUniqueId());
+                final Quester quester = new BukkitQuester(BukkitQuestsPlugin.this, p.getUniqueId());
                 if (!quester.hasData()) {
                     quester.saveData();
                 }
                 quester.findCompassTarget();
-                questers.add(quester);
+                questers.put(p.getUniqueId(), quester);
             }
             loading = false;
         }, 60L);
@@ -695,7 +695,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
                 conditionLoader.init();
                 actionLoader.init();
                 questLoader.init();
-                for (final Quester quester : questers) {
+                for (final Quester quester : questers.values()) {
                     final Quester loaded = getStorage().loadQuester(quester.getUUID()).get();
                     if (loaded == null) {
                         getLogger().severe("Unable to load quester of UUID " + quester.getUUID());
@@ -730,7 +730,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
             getServer().getScheduler().runTask(BukkitQuestsPlugin.this, () -> {
                 loading = false;
                 callback.execute(result);
-                
+
                 final BukkitQuestsPluginPostReloadEvent event = new BukkitQuestsPluginPostReloadEvent(result, exception);
                 getServer().getPluginManager().callEvent(event);
             });
@@ -739,7 +739,7 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
 
     /**
      * Checks if player can use the Quests plugin
-     * 
+     *
      * @param uuid the entity UUID to be checked
      * @return {@code true} if entity is a Player that has permission
      */
@@ -790,10 +790,10 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
         }
         return null;
     }
-    
+
     /**
      * Get a Quest by name
-     * 
+     *
      * @param name Name of the quest
      * @return Closest match or null if not found
      */
@@ -825,10 +825,10 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
         }
         return null;
     }
-    
+
     /**
      * Get an Action by name
-     * 
+     *
      * @param name Name of the action
      * @return Closest match or null if not found
      */
@@ -860,10 +860,10 @@ public class BukkitQuestsPlugin extends JavaPlugin implements Quests {
         }
         return null;
     }
-    
+
     /**
      * Get a Condition by name
-     * 
+     *
      * @param name Name of the condition
      * @return Closest match or null if not found
      */

--- a/bukkit/src/main/java/me/pikamug/quests/commands/questadmin/subcommands/BukkitQuestadminResetCommand.java
+++ b/bukkit/src/main/java/me/pikamug/quests/commands/questadmin/subcommands/BukkitQuestadminResetCommand.java
@@ -105,7 +105,7 @@ public class BukkitQuestadminResetCommand extends BukkitQuestsSubCommand {
             }
             quester = new BukkitQuester(plugin, id);
             quester.saveData();
-            plugin.upsertQuester(quester);
+            plugin.addQuester(quester);
         } else {
             cs.sendMessage(ChatColor.RED + BukkitLang.get("noPermission"));
         }

--- a/bukkit/src/main/java/me/pikamug/quests/commands/questadmin/subcommands/BukkitQuestadminResetCommand.java
+++ b/bukkit/src/main/java/me/pikamug/quests/commands/questadmin/subcommands/BukkitQuestadminResetCommand.java
@@ -23,7 +23,6 @@ import org.bukkit.command.CommandSender;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
 public class BukkitQuestadminResetCommand extends BukkitQuestsSubCommand {
@@ -84,9 +83,7 @@ public class BukkitQuestadminResetCommand extends BukkitQuestsSubCommand {
                 return;
             }
             final UUID id = target.getUniqueId();
-            final Set<Quester> temp = plugin.getOfflineQuesters();
-            temp.removeIf(quester -> quester.getUUID().equals(id));
-            plugin.setOfflineQuesters(temp);
+            plugin.removeQuester(id);
             Quester quester = plugin.getQuester(id);
             try {
                 quester.resetCompass();
@@ -108,9 +105,7 @@ public class BukkitQuestadminResetCommand extends BukkitQuestsSubCommand {
             }
             quester = new BukkitQuester(plugin, id);
             quester.saveData();
-            final Set<Quester> temp2 = plugin.getOfflineQuesters();
-            temp2.add(quester);
-            plugin.setOfflineQuesters(temp2);
+            plugin.upsertQuester(quester);
         } else {
             cs.sendMessage(ChatColor.RED + BukkitLang.get("noPermission"));
         }

--- a/bukkit/src/main/java/me/pikamug/quests/listeners/BukkitPlayerListener.java
+++ b/bukkit/src/main/java/me/pikamug/quests/listeners/BukkitPlayerListener.java
@@ -984,10 +984,7 @@ public class BukkitPlayerListener implements Listener {
                 temp.remove(event.getPlayer().getUniqueId());
                 plugin.getQuestFactory().setSelectingNpcs(temp);
             }
-            final Set<Quester> temp = plugin.getOfflineQuesters();
-            temp.removeIf(q -> q.getUUID().equals(quester.getUUID()));
-            temp.add(quester);
-            plugin.setOfflineQuesters(temp);
+            plugin.upsertQuester(quester);
         }
     }
 

--- a/bukkit/src/main/java/me/pikamug/quests/listeners/BukkitPlayerListener.java
+++ b/bukkit/src/main/java/me/pikamug/quests/listeners/BukkitPlayerListener.java
@@ -984,7 +984,7 @@ public class BukkitPlayerListener implements Listener {
                 temp.remove(event.getPlayer().getUniqueId());
                 plugin.getQuestFactory().setSelectingNpcs(temp);
             }
-            plugin.upsertQuester(quester);
+            plugin.addQuester(quester);
         }
     }
 

--- a/bukkit/src/main/java/me/pikamug/quests/player/BukkitQuester.java
+++ b/bukkit/src/main/java/me/pikamug/quests/player/BukkitQuester.java
@@ -75,20 +75,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.AbstractSet;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Random;
-import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -97,7 +85,7 @@ import java.util.stream.Collectors;
 public class BukkitQuester implements Quester {
 
     private final BukkitQuestsPlugin plugin;
-    private UUID id;
+    private final UUID id;
     protected String questIdToTake;
     protected String questIdToQuit;
     private String lastKnownName;
@@ -260,6 +248,18 @@ public class BukkitQuester implements Quester {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof BukkitQuester)) return false;
+        BukkitQuester that = (BukkitQuester) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    @Override
     public Quests getPlugin() {
         return plugin;
     }
@@ -267,11 +267,6 @@ public class BukkitQuester implements Quester {
     @Override
     public UUID getUUID() {
         return id;
-    }
-
-    @Override
-    public void setUUID(final UUID id) {
-        this.id = id;
     }
 
     @Override


### PR DESCRIPTION
* Use a `ConcurrentHashMap<UUID, Quester>` for `questers` instead of a `Set<Quester>` for faster lookups
* Added `upsertQuester` and `removeQuester`
* Removed `setOfflineQuesters`

Improves performance and encapsulation without changing the intended behavior.
**Note**: `getOfflineQuesters` now returns an unmodifiable collection.